### PR TITLE
[debug] renamed global functions that triggered E128

### DIFF
--- a/plugin/vimim.vim
+++ b/plugin/vimim.vim
@@ -470,17 +470,17 @@ function! s:vimim_dictionary_punctuations()
     endif
 endfunction
 
-function! g:vimim_slash()
+function! g:Vimim_slash()
     let range = col(".") - 1 - s:starts.column
     let chinese = strpart(getline("."), s:starts.column, range)
     let word = substitute(chinese,'\w','','g')
     let @/ = empty(word) ? @_ : word
     let repeat_times = len(word) / s:multibyte
-    let key = repeat("\<Left>\<Delete>",repeat_times) . g:vimim_esc()
+    let key = repeat("\<Left>\<Delete>",repeat_times) . g:Vimim_esc()
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
-function! g:vimim_bracket(offset)
+function! g:Vimim_bracket(offset)
     let cursor = ""
     let range = col(".") - 1 - s:starts.column
     let repeat_times = range / s:multibyte + a:offset
@@ -603,7 +603,7 @@ function! s:vimim_windowless_titlestring(cursor)
     sil!call s:vimim_set_title(logo)
 endfunction
 
-function! g:vimim_esc()
+function! g:Vimim_esc()
     let key = nr2char(27)  "  <Esc> is <Esc> if onekey or windowless
     if s:mode.windowless || s:mode.onekey
         if has("gui_running")
@@ -612,7 +612,7 @@ function! g:vimim_esc()
         sil!let key = s:vimim_stop() . key     " <Esc> to escape
         sil!call s:vimim_set_title(s:space . getline("."))
     elseif pumvisible()
-        let key = g:vimim_one_key_correction() " <Esc> as correction
+        let key = g:Vimim_one_key_correction() " <Esc> as correction
     endif
     sil!exe 'sil!return "' . key . '"'
 endfunction
@@ -621,7 +621,7 @@ endfunction
 let s:VimIM += [" ====  lmap imap nmap   ==== {{{"]
 " =================================================
 
-function! g:vimim_cycle_vimim()
+function! g:Vimim_cycle_vimim()
     if len(s:cjk.filename)  " backdoor to cycle all 4 vimim modes
         let s:mode = s:mode.windowless ? s:onekey  :
                    \ s:mode.onekey     ? s:dynamic :
@@ -637,7 +637,7 @@ function! g:vimim_cycle_vimim()
     return ""
 endfunction
 
-function! g:vimim_label(key)
+function! g:Vimim_label(key)
     let key = a:key
     if pumvisible()
         let n = match(s:abcd, key)
@@ -645,7 +645,7 @@ function! g:vimim_label(key)
             let n = key < 1 ? 9 : key - 1
         endif
         let yes = repeat("\<Down>", n). '\<C-Y>'
-        let omni = '\<C-R>=g:vimim()\<CR>'
+        let omni = '\<C-R>=g:Vimim()\<CR>'
         if s:mode.onekey
             if s:vimim_cjk() && a:key =~ '\d'
                 let s:hjkl .= a:key  " 1234567890 as filter
@@ -664,15 +664,15 @@ function! g:vimim_label(key)
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
-function! g:vimim_page(key)
+function! g:Vimim_page(key)
     let key = a:key
     if pumvisible()
-        let page = '\<C-E>\<C-R>=g:vimim()\<CR>'
+        let page = '\<C-E>\<C-R>=g:Vimim()\<CR>'
         if key =~ '[][]'
             let left  = key == "]" ? "\<Left>"  : ""
             let right = key == "]" ? "\<Right>" : ""
             let _ = key == "]" ? 0 : -1
-            let backspace = '\<C-R>=g:vimim_bracket('._.')\<CR>'
+            let backspace = '\<C-R>=g:Vimim_bracket('._.')\<CR>'
             let key = '\<C-Y>' . left . backspace . right
         elseif key =~ '[=.]'
             let s:pageup_pagedown = &pumheight ? 1 : 0
@@ -682,12 +682,12 @@ function! g:vimim_page(key)
             let key = &pumheight ? page : '\<PageUp>'
         endif
     elseif key =~ "[][=-]" && empty(s:mode.onekey)
-        let key = g:punctuation(key)
+        let key = g:Punctuation(key)
     endif
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
-function! g:wubi()
+function! g:Wubi()
     if s:gi_dynamic_on
         let s:gi_dynamic_on = 0 | return ""
     endif
@@ -698,7 +698,7 @@ function! g:wubi()
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
-function! g:vimim_hjkl(key)
+function! g:Vimim_hjkl(key)
     let key = a:key
     if pumvisible()
             if key ==# 'n' | call s:vimim_reset_after_insert()
@@ -709,11 +709,11 @@ function! g:vimim_hjkl(key)
         elseif key ==# 'l' | let s:hjkl_l += 1   " l
         elseif key ==# 's' | let s:hjkl__ += 1   " s/t transfer
         elseif key =~ "[/?]"
-            let key = '\<C-Y>\<C-R>=g:vimim_slash()\<CR>' . key . '\<CR>'
+            let key = '\<C-Y>\<C-R>=g:Vimim_slash()\<CR>' . key . '\<CR>'
         elseif match(s:qwer, key) > -1
             let s:hjkl .= match(s:qwer, key)
         endif
-        let key = key == a:key ? '\<C-R>=g:vimim()\<CR>' : key
+        let key = key == a:key ? '\<C-R>=g:Vimim()\<CR>' : key
     endif
     sil!exe 'sil!return "' . key . '"'
 endfunction
@@ -721,19 +721,19 @@ endfunction
 function! s:vimim_punctuation_maps()
     for _ in keys(s:all_evils)
         if _ !~ s:valid_keyboard
-            exe 'lnoremap<buffer><expr> '._.' g:punctuation("'._.'")'
+            exe 'lnoremap<buffer><expr> '._.' g:Punctuation("'._.'")'
         endif
     endfor
     if empty(s:ui.quote)
-        lnoremap<buffer> ' <C-R>=g:vimim_single_quote()<CR>
+        lnoremap<buffer> ' <C-R>=g:Vimim_single_quote()<CR>
     endif
     if g:vimim_punctuation == 3
         lnoremap<buffer>    "     <C-R>=g:vimim_double_quote()<CR>
-        lnoremap<buffer> <Bslash> <C-R>=g:vimim_bslash()<CR>
+        lnoremap<buffer> <Bslash> <C-R>=g:Vimim_bslash()<CR>
     endif
 endfunction
 
-function! g:punctuation(key)
+function! g:Punctuation(key)
     let key = a:key
     if s:toggle_punctuation > 0
         if pumvisible() || getline(".")[col(".")-2] !~ '\w'
@@ -746,18 +746,18 @@ function! g:punctuation(key)
         let key = a:key == ";" ? '\<C-N>\<C-Y>' : '\<C-Y>' . key
     elseif s:mode.windowless && s:gi_dynamic
         let key = a:key == ";" ? '\<C-N>' : key
-        call g:vimim_space()
+        call g:Vimim_space()
     endif
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
-function! g:vimim_single_quote()
+function! g:Vimim_single_quote()
     let key = "'"
     if pumvisible()       " the 3rd choice
         let key = '\<C-N>\<C-N>\<C-Y>'
     elseif s:mode.windowless && s:gi_dynamic
         let key = '\<C-N>\<C-N>'
-        call g:vimim_space()
+        call g:Vimim_space()
     elseif g:vimim_punctuation < 3
         return key
     elseif s:toggle_punctuation > 0
@@ -768,7 +768,7 @@ function! g:vimim_single_quote()
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
-function! g:vimim_double_quote()
+function! g:Vimim_double_quote()
     let key = '"'
     if s:toggle_punctuation > 0
         let pairs = split(s:key_evils[key], '\zs')
@@ -779,7 +779,7 @@ function! g:vimim_double_quote()
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
-function! g:vimim_bslash()
+function! g:Vimim_bslash()
     let key = '\'
     if s:toggle_punctuation > 0
         let yes = pumvisible() ? '\<C-Y>' : ""
@@ -792,13 +792,13 @@ endfunction
 let s:VimIM += [" ====  mode: windowless ==== {{{"]
 " =================================================
 
-function! g:vimim_gi()
+function! g:Vimim_gi()
     let s:mode = s:windowless
     let key = s:vimim_start()
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
-function! g:vimim_tab(gi)
+function! g:Vimim_tab(gi)
     " (1) Tab in insert mode => start Tab or windowless/onekey
     " (2) Tab in pumvisible  => print out menu
     let key = "\t"
@@ -819,7 +819,7 @@ function! s:vimim_windowless(key)
     if s:pattern_not_found   " gi ma space xj space ctrl+u space
     elseif s:vimim_left() && s:keyboard !~ ' ' " gi mmm.. space 7 space
     elseif s:omni " assume completion active
-        let key = len(a:key) ? '\<C-E>\<C-R>=g:vimim()\<CR>' : '\<C-N>'
+        let key = len(a:key) ? '\<C-E>\<C-R>=g:Vimim()\<CR>' : '\<C-N>'
         let cursor = empty(len(a:key)) ? 1 : a:key < 1 ? 9 : a:key-1
         if s:vimim_cjk()              " gi ma space isw8ql
             let s:hjkl .= a:key       " 1234567890 for windowless filter
@@ -833,16 +833,16 @@ function! s:vimim_windowless(key)
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
-function! g:vimim_pagedown()
+function! g:Vimim_pagedown()
     let key = ' '
     if pumvisible()
         let s:pageup_pagedown = &pumheight ? 1 : 0
-        let key = &pumheight ? g:vimim() : '\<PageDown>'
+        let key = &pumheight ? g:Vimim() : '\<PageDown>'
     endif
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
-function! g:vimim_space()
+function! g:Vimim_space()
     " (1) Space after English (valid keys)    => trigger keycode menu
     " (2) Space after omni popup menu         => insert Chinese
     " (3) Space after pattern not found       => Space
@@ -850,7 +850,7 @@ function! g:vimim_space()
     " (5) Space after chinese windowless wubi => deactive completion
     let key = " "
     if pumvisible()
-        let key = '\<C-R>=g:vimim()\<CR>'
+        let key = '\<C-R>=g:Vimim()\<CR>'
         if s:mode.onekey && s:hit_and_run
              let key = s:vimim_stop()
         endif
@@ -859,7 +859,7 @@ function! g:vimim_space()
     elseif s:pattern_not_found
     elseif s:mode.dynamic
     elseif s:mode.static
-        let key = s:vimim_left() ? g:vimim() : key
+        let key = s:vimim_left() ? g:Vimim() : key
     elseif s:seamless_positions == getpos(".") " gi ma space enter space
         let s:smart_enter = 0              " Space is Space after Enter
     elseif s:mode.windowless && s:gi_dynamic
@@ -873,7 +873,7 @@ function! g:vimim_space()
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
-function! g:vimim_enter()
+function! g:Vimim_enter()
     let s:omni = 0
     let key = ""
     if pumvisible()
@@ -897,13 +897,13 @@ function! g:vimim_enter()
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
-function! g:vimim_one_key_correction()
+function! g:Vimim_one_key_correction()
     " :help i_CTRL-U  Delete all entered characters ...
     let key = nr2char(21)
     if s:mode.windowless || s:mode.static && pumvisible()
         if s:omni " one_key_correction " gi m space a space ctrl+u
             let s:omni = -1            " gi mamahuhu space ctrl+u ctrl+u
-            let key  = '\<C-E>\<C-R>=g:vimim()\<CR>\<Left>\<Delete>'
+            let key  = '\<C-E>\<C-R>=g:Vimim()\<CR>\<Left>\<Delete>'
         endif
     elseif pumvisible()
         let range = col(".") - 1 - s:starts.column
@@ -913,10 +913,10 @@ function! g:vimim_one_key_correction()
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
-function! g:vimim_backspace()
+function! g:Vimim_backspace()
     " <BS> has special meaning in all 3 states of popupmenu-completion
     let s:omni = 0  " disable active omni completion state
-    let key = pumvisible() ? '\<C-R>=g:vimim()\<CR>' : ''
+    let key = pumvisible() ? '\<C-R>=g:Vimim()\<CR>' : ''
     let key = '\<Left>\<Delete>' . key
     sil!exe 'sil!return "' . key . '"'
 endfunction
@@ -941,7 +941,7 @@ function! s:vimim_screenshot()
         put=space.line
     endfor
     call setpos(".", saved_position)
-    let key = g:vimim_esc()
+    let key = g:Vimim_esc()
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
@@ -949,7 +949,7 @@ endfunction
 let s:VimIM += [" ====  mode: onekey     ==== {{{"]
 " =================================================
 
-function! g:vimim_onekey()
+function! g:Vimim_onekey()
     " (1) OneKey in insert  mode => start omni popup mode
     " (2) OneKey in onekey  mode => close omni popup mode
     " (3) OneKey in chinese mode => switch to the next im
@@ -979,7 +979,7 @@ function! s:vimim_onekey_action()
     let key = s:vimim_onekey_evils()
     if empty(key)
         if s:vimim_left()
-            let key = g:vimim()
+            let key = g:Vimim()
         elseif s:mode.windowless
             let key = s:vimim_windowless("")
         endif
@@ -1003,7 +1003,7 @@ function! s:vimim_onekey_evils()
         else
             let key = "''"       "  <=  香.. plays same cjk
         endif
-        let key = "\<BS>\<BS>" . key . '\<C-R>=g:vimim()\<CR>'
+        let key = "\<BS>\<BS>" . key . '\<C-R>=g:Vimim()\<CR>'
     elseif one == "'" && two =~ "[a-z']" " force cloud
     elseif one =~# "[0-9a-z]" || one =~# '\s' || empty(one)
     elseif two =~# "[0-9a-z]" || one =~# '\u'
@@ -1048,7 +1048,7 @@ endfunction
 let s:VimIM += [" ====  mode: chinese    ==== {{{"]
 " =================================================
 
-function! g:vimim_chinese()
+function! g:Vimim_chinese()
     let s:mode = g:vimim_mode =~ 'static' ? s:static : s:dynamic
     let s:switch = empty(s:ui.frontends) ? -1 : s:switch ? 0 : 1
     return s:switch<0 ? "" : s:switch ? s:vimim_start() : s:vimim_stop()
@@ -1062,7 +1062,7 @@ function! s:vimim_set_keyboard_maps()
     if both_dynamic
         for char in s:valid_keys
             sil!exe 'lnoremap<silent><buffer> ' . char . ' ' .
-            \ '<C-R>=g:wubi()<CR>' . char . '<C-R>=g:vimim()<CR>'
+            \ '<C-R>=g:Wubi()<CR>' . char . '<C-R>=g:Vimim()<CR>'
         endfor
     elseif s:mode.static
         for char in s:valid_keys
@@ -1073,7 +1073,7 @@ function! s:vimim_set_keyboard_maps()
         let common_labels += s:abcd[1:]
         let pqwertyuio = s:vimim_cjk() ?  s:qwer : []
         for _ in pqwertyuio + split("h j k l m n / ? s")
-             sil!exe 'lnoremap<buffer><expr> '._.' g:vimim_hjkl("'._.'")'
+             sil!exe 'lnoremap<buffer><expr> '._.' g:Vimim_hjkl("'._.'")'
         endfor
     endif
     if g:vimim_punctuation < 0
@@ -1082,11 +1082,11 @@ function! s:vimim_set_keyboard_maps()
     endif
     for _ in s:mode.windowless ? [] : common_punctuations
         if _ !~ s:valid_keyboard
-            sil!exe 'lnoremap<buffer><expr> '._.' g:vimim_page("'._.'")'
+            sil!exe 'lnoremap<buffer><expr> '._.' g:Vimim_page("'._.'")'
         endif
     endfor
     for _ in common_labels
-        sil!exe 'lnoremap<buffer><expr> '._.' g:vimim_label("'._.'")'
+        sil!exe 'lnoremap<buffer><expr> '._.' g:Vimim_label("'._.'")'
     endfor
 endfunction
 
@@ -1140,7 +1140,7 @@ endfunction
 let s:VimIM += [" ====  input: visual    ==== {{{"]
 " =================================================
 
-function! g:vimim_visual()
+function! g:Vimim_visual()
     let key = ""
     let lines = split(getreg('"'), '\n')
     let line = get(lines,0)
@@ -1164,7 +1164,7 @@ function! g:vimim_visual()
         let key = "o" . nr2char(4) . space . " " . line . nr2char(27)
     else
         sil!call s:vimim_start()
-        let visual = nr2char(30) . "\<C-R>=g:vimim()\<CR>"
+        let visual = nr2char(30) . "\<C-R>=g:Vimim()\<CR>"
         if len(lines) < 2 " highlight multiple cjk => show property
             let s:seamless_positions = getpos("'<'")
             let chinese = get(split(line,'\zs'),0)
@@ -2692,7 +2692,7 @@ endfunction
 let s:VimIM += [" ====  /search          ==== {{{"]
 " =================================================
 
-function! g:vimim_search()
+function! g:Vimim_search()
     let results = []
     let english = @/
     if len(english) > 1 && len(english) < 20 && english !~ "[^0-9a-z']"
@@ -2766,16 +2766,16 @@ function! s:vimim_start()
     sil!call s:vimim_set_vimrc()
     sil!call s:vimim_set_frontend()
     sil!call s:vimim_set_keyboard_maps()
-    lnoremap <silent><buffer> <expr> <BS>    g:vimim_backspace()
-    lnoremap <silent><buffer> <expr> <Esc>   g:vimim_esc()
-    lnoremap <silent><buffer> <expr> <C-U>   g:vimim_one_key_correction()
-    lnoremap <silent><buffer> <expr> <C-L>   g:vimim_cycle_vimim()
+    lnoremap <silent><buffer> <expr> <BS>    g:Vimim_backspace()
+    lnoremap <silent><buffer> <expr> <Esc>   g:Vimim_esc()
+    lnoremap <silent><buffer> <expr> <C-U>   g:Vimim_one_key_correction()
+    lnoremap <silent><buffer> <expr> <C-L>   g:Vimim_cycle_vimim()
     if s:ui.im =~ 'array'
-        lnoremap <silent><buffer> <expr> <CR>    g:vimim_space()
-        lnoremap <silent><buffer> <expr> <Space> g:vimim_pagedown()
+        lnoremap <silent><buffer> <expr> <CR>    g:Vimim_space()
+        lnoremap <silent><buffer> <expr> <Space> g:Vimim_pagedown()
     else
-        lnoremap <silent><buffer> <expr> <CR>    g:vimim_enter()
-        lnoremap <silent><buffer> <expr> <Space> g:vimim_space()
+        lnoremap <silent><buffer> <expr> <CR>    g:Vimim_enter()
+        lnoremap <silent><buffer> <expr> <Space> g:Vimim_space()
     endif
     let key = ''
     if empty(s:ctrl6)
@@ -3122,14 +3122,14 @@ function! s:vimim_embedded_backend_engine(keyboard)
     return results
 endfunction
 
-function! g:vimim()
+function! g:Vimim()
     let s:omni = s:omni < 0 ? -1 : 0  " one_key_correction
     let s:keyboard = empty(s:pageup_pagedown) ? "" : s:keyboard
-    let key = s:vimim_left() ? '\<C-X>\<C-O>\<C-R>=g:omni()\<CR>' : ""
+    let key = s:vimim_left() ? '\<C-X>\<C-O>\<C-R>=g:Omni()\<CR>' : ""
     sil!exe 'sil!return "' . key . '"'
 endfunction
 
-function! g:omni()
+function! g:Omni()
     let s:omni = s:omni < 0 ? 0 : 1 " as if omni completion pattern found
     let key = s:mode.static ? '\<C-N>\<C-P>' : '\<C-P>\<Down>'
     let key = pumvisible() ? key : ""
@@ -3141,16 +3141,16 @@ let s:VimIM += [" ====  core driver      ==== {{{"]
 " =================================================
 
 function! s:vimim_plug_and_play()
-    nnoremap <silent> <C-_> i<C-R>=g:vimim_chinese()<CR><Esc>
-    inoremap <unique> <C-_>  <C-R>=g:vimim_chinese()<CR>
-    inoremap <silent> <C-^>  <C-R>=g:vimim_onekey()<CR>
-    xnoremap <silent> <C-^> y:call g:vimim_visual()<CR>
+    nnoremap <silent> <C-_> i<C-R>=g:Vimim_chinese()<CR><Esc>
+    inoremap <unique> <C-_>  <C-R>=g:Vimim_chinese()<CR>
+    inoremap <silent> <C-^>  <C-R>=g:Vimim_onekey()<CR>
+    xnoremap <silent> <C-^> y:call g:Vimim_visual()<CR>
     if g:vimim_map !~ 'no-gi'
-        nnoremap <silent> gi a<C-R>=g:vimim_gi()<CR>
+        nnoremap <silent> gi a<C-R>=g:Vimim_gi()<CR>
             xmap <silent> gi  <C-^>
     endif
     if g:vimim_map !~ 'no-search'
-        nnoremap <silent> n :call g:vimim_search()<CR>n
+        nnoremap <silent> n :call g:Vimim_search()<CR>n
     endif
     if g:vimim_map =~ 'c-bslash'      " use Ctrl-\  ''
         imap <C-Bslash> <C-_>
@@ -3170,9 +3170,9 @@ function! s:vimim_plug_and_play()
     if g:vimim_map =~ 'tab'           " use Tab
         xmap <silent> <Tab> <C-^>
         if g:vimim_map =~ 'tab_as_gi'
-            inoremap <silent> <Tab> <C-R>=g:vimim_tab(1)<CR>
+            inoremap <silent> <Tab> <C-R>=g:Vimim_tab(1)<CR>
         elseif g:vimim_map =~ 'tab_as_onekey'
-            inoremap <silent> <Tab> <C-R>=g:vimim_tab(0)<CR>
+            inoremap <silent> <Tab> <C-R>=g:Vimim_tab(0)<CR>
         endif
     endif
     :com! -range=% ViMiM <line1>,<line2>call s:vimim_chinese_rotation()


### PR DESCRIPTION
As per vim patch 7.4.260 [1], naming convection of user defined
functions are enforced (namely error code E128).
This commit renamed all those functions that begin with g: and were
followed by lowercase letters to g: with corresponding uppercase
letters.

[1] https://groups.google.com/forum/#!topic/vim_dev/M4_E1QhXVxA
